### PR TITLE
ci: limit releases to only occur on relevant dependency updates

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -44,6 +44,7 @@ jobs:
               { "release": "patch", "type": "build" },
               { "release": "patch", "type": "chore", "scope": "deps" },
               { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "bump typescript from*" },
+              { "release": "patch", "type": "chore" },
               { "release": "patch", "type": "ci" },
               { "release": "patch", "type": "improvement" },
               { "release": "patch", "type": "refactor" }

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -39,12 +39,19 @@ jobs:
           commit-assets: |
             ./dist
           node-module: true
+          release-rules:
+            '[ { "release": "patch", "type": "build" }, { "release": "patch",
+            "type": "chore", "scope": "deps" }, { "release": "patch", "type":
+            "chore", "scope": "deps-dev", "message": "*typescript*" }, {
+            "release": "patch", "type": "ci" }, { "release": "patch", "type":
+            "docs" }, { "release": "patch", "type": "improvement" }, {
+            "release": "patch", "type": "refactor" }, ]'
       - if: steps.release.outputs.released == 'true'
         name: Authenticate
         uses: actions/checkout@v2
         with:
-          fetch-depth: 1
           persist-credentials: true
+          ref: master
           token: ${{ secrets.DOTTBOTT_TOKEN }}
       - if: steps.release.outputs.released == 'true'
         name: Tag

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -53,8 +53,8 @@ jobs:
         name: Authenticate
         uses: actions/checkout@v2
         with:
+          fetch-depth: 1
           persist-credentials: true
-          ref: master
           token: ${{ secrets.DOTTBOTT_TOKEN }}
       - if: steps.release.outputs.released == 'true'
         name: Tag

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -44,6 +44,7 @@ jobs:
               { "release": "patch", "type": "build" },
               { "release": "patch", "type": "chore", "scope": "deps" },
               { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "bump typescript from*" },
+              { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "bump @zeit/ncc from*" },
               { "release": "patch", "type": "chore" },
               { "release": "patch", "type": "ci" },
               { "release": "patch", "type": "improvement" },

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -39,13 +39,16 @@ jobs:
           commit-assets: |
             ./dist
           node-module: true
-          release-rules:
-            '[ { "release": "patch", "type": "build" }, { "release": "patch",
-            "type": "chore", "scope": "deps" }, { "release": "patch", "type":
-            "chore", "scope": "deps-dev", "message": "*typescript*" }, {
-            "release": "patch", "type": "ci" }, { "release": "patch", "type":
-            "docs" }, { "release": "patch", "type": "improvement" }, {
-            "release": "patch", "type": "refactor" }, ]'
+          release-rules: |
+            [
+              { "release": "patch", "type": "build" },
+              { "release": "patch", "type": "chore", "scope": "deps" },
+              { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "*typescript*" },
+              { "release": "patch", "type": "ci" },
+              { "release": "patch", "type": "docs" },
+              { "release": "patch", "type": "improvement" },
+              { "release": "patch", "type": "refactor" }
+            ]
       - if: steps.release.outputs.released == 'true'
         name: Authenticate
         uses: actions/checkout@v2

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -45,7 +45,6 @@ jobs:
               { "release": "patch", "type": "chore", "scope": "deps" },
               { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "bump typescript from*" },
               { "release": "patch", "type": "ci" },
-              { "release": "patch", "type": "docs" },
               { "release": "patch", "type": "improvement" },
               { "release": "patch", "type": "refactor" }
             ]

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -45,6 +45,7 @@ jobs:
               { "release": "patch", "type": "chore", "scope": "deps" },
               { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "bump typescript from*" },
               { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "bump @zeit/ncc from*" },
+              { "release": false, "type": "chore", "scope": "deps-dev" },
               { "release": "patch", "type": "chore" },
               { "release": "patch", "type": "ci" },
               { "release": "patch", "type": "improvement" },

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -43,7 +43,7 @@ jobs:
             [
               { "release": "patch", "type": "build" },
               { "release": "patch", "type": "chore", "scope": "deps" },
-              { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "*typescript*" },
+              { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "bump typescript from*" },
               { "release": "patch", "type": "ci" },
               { "release": "patch", "type": "docs" },
               { "release": "patch", "type": "improvement" },


### PR DESCRIPTION
Limit releases triggered by development dependency updates to only occur when relevant packages are updated.