### PR TITLE
chore: limit development dependency releases

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -42,11 +42,10 @@ jobs:
           release-rules: |
             [
               { "release": "patch", "type": "build" },
-              { "release": "patch", "type": "chore", "scope": "deps" },
-              { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "bump typescript from*" },
-              { "release": "patch", "type": "chore", "scope": "deps-dev", "message": "bump @zeit/ncc from*" },
-              { "release": false, "type": "chore", "scope": "deps-dev" },
               { "release": "patch", "type": "chore" },
+              { "release": false, "type": "chore", "scope": "deps-dev" },
+              { "release": "patch", "type": "chore", "scope": "deps-dev", "subject": "bump typescript from*" },
+              { "release": "patch", "type": "chore", "scope": "deps-dev", "subject": "bump @zeit/ncc from*" },
               { "release": "patch", "type": "ci" },
               { "release": "patch", "type": "improvement" },
               { "release": "patch", "type": "refactor" }


### PR DESCRIPTION
Limit releases to only trigger on chores updating the following development dependencies:
- typescript
- @zeit/ncc