### PR TITLE
fix: escape brackets

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -49,7 +49,7 @@ jobs:
               { "release": "patch", "type": "ci" },
               { "release": "patch", "type": "improvement" },
               { "release": "patch", "type": "refactor" },
-              { "release": false, "subject": "*[skip release]*" }
+              { "release": false, "subject": "*\\[skip release\\]*" }
             ]
       - if: steps.release.outputs.released == 'true'
         name: Authenticate

--- a/src/utilities/inputProcessors.spec.ts
+++ b/src/utilities/inputProcessors.spec.ts
@@ -176,7 +176,7 @@ describe('processInputReleaseRules', (): void => {
       { release: 'patch', type: 'docs' },
       { release: 'patch', type: 'improvement' },
       { release: 'patch', type: 'refactor' },
-      { release: false, subject: '*\\[skip release\\]*' },
+      { release: false, subject: "*\\[skip release\\]*" },
     ]);
   });
 

--- a/src/utilities/inputProcessors.spec.ts
+++ b/src/utilities/inputProcessors.spec.ts
@@ -176,7 +176,7 @@ describe('processInputReleaseRules', (): void => {
       { release: 'patch', type: 'docs' },
       { release: 'patch', type: 'improvement' },
       { release: 'patch', type: 'refactor' },
-      { release: false, subject: '*[skip release]*' },
+      { release: false, subject: '*\\[skip release\\]*' },
     ]);
   });
 

--- a/src/utilities/inputProcessors.ts
+++ b/src/utilities/inputProcessors.ts
@@ -31,7 +31,7 @@ export const DEFAULT_RELEASE_RULES: ReleaseRule[] = [
   { release: 'patch', type: 'docs' },
   { release: 'patch', type: 'improvement' },
   { release: 'patch', type: 'refactor' },
-  { release: false, subject: '*[skip release]*' },
+  { release: false, subject: '*\\[skip release\\]*' },
 ];
 
 const inputReleaseBranchesSchema = joi


### PR DESCRIPTION
The glob definition says:

```
The glob module finds all the pathnames matching a specified pattern according to the rules used by the Unix shell, although results are returned in arbitrary order. No tilde expansion is done, but *, ?, and character ranges expressed with [] will be correctly matched.
```

This means `*[skip release]*` was, most likely, matching any sentence that would have that set of letters in it. After several tests (that can be seem in the links below), escaping the brackets will fix the issue. See test references in the following links:

- With the rule `{ release: false, subject: '*[skip release]*' }`: [it fails, no release is created](https://github.com/ridedott/mad-framework/runs/902845575?check_suite_focus=true)
- Completely removing the rule `{ release: false, subject: '*[skip release]*' }`: [it works, a release is created](https://github.com/ridedott/mad-framework/runs/902818238?check_suite_focus=true)

- Escaping the brackets (`{ release: false, subject: '*\\[skip release\\]*' }`): [it works, a release is created](https://github.com/ridedott/mad-framework/runs/902862004?check_suite_focus=true)