### PR TITLE
feat: allow for disabling changelog creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ steps:
     name: Release
     uses: ridedott/release-me-action@master
     with:
-      disable-generate-changelog: true
+      disable-changelog: true
 ```
 
 ## Output release details

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ performing the following tasks:
 
 - analyzes commits based on the
   [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)
-- updates the `CHANGELOG.md` file based on the analyzed commits
+- optionally, omits creating or updating the `CHANGELOG.md` file based on the
+  analyzed commits
 - optionally, bumps the NPM package version number
 - optionally, commits workflow generated assets to the repository
 - optionally, adds workflow generated assets to the release
@@ -70,6 +71,7 @@ with the required permissions enabled on it.
 # Scenarios
 
 - [Create a release](#create-a-release)
+- [Create a release without a CHANGELOG.md file](#create-a-release-without-changelog)
 - [Test a release](#test-a-release)
 - [Create a release to a different branch](#create-a-release-to-a-different-branch)
 - [Create a release and update repository contents](#create-a-release-and-update-repository-contents)
@@ -86,6 +88,18 @@ steps:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     name: Release
     uses: ridedott/release-me-action@master
+```
+
+## Create a release without a CHANGELOG.md file
+
+```yaml
+steps:
+  - env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    name: Release
+    uses: ridedott/release-me-action@master
+    with:
+      disable-generate-changelog: true
 ```
 
 ## Output release details

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
       Configures the list of assets to commit to the repository alongside the
       changelog.
     required: false
-  disable-generate-changelog:
+  disable-changelog:
     default: 'false'
     description: Skips generating a CHANGELOG.md file.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
       Configures the list of assets to commit to the repository alongside the
       changelog.
     required: false
+  disable-generate-changelog:
+    default: 'false'
+    description: Skips generating a CHANGELOG.md file.
+    required: false
   dry-run:
     default: 'false'
     description: Configures Semantic Release to run in dry-run mode.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { Config, Options, Result } from 'semantic-release';
 import { generatePlugins } from './utilities/generatePlugins';
 import {
   processInputCommitAssets,
-  processInputDisableGenerateChangelog,
+  processInputDisableChangelog,
   processInputDryRun,
   processInputNodeModule,
   processInputReleaseAssets,
@@ -52,7 +52,7 @@ export const release = async (
       parserOpts: parseOptions,
       plugins: generatePlugins({
         commitAssets: processInputCommitAssets(),
-        disableGenerateChangeLog: processInputDisableGenerateChangelog(),
+        disableChangeLog: processInputDisableChangelog(),
         isNodeModule: processInputNodeModule(),
         releaseAssets: processInputReleaseAssets(),
       }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Config, Options, Result } from 'semantic-release';
 import { generatePlugins } from './utilities/generatePlugins';
 import {
   processInputCommitAssets,
+  processInputDisableGenerateChangelog,
   processInputDryRun,
   processInputNodeModule,
   processInputReleaseAssets,
@@ -51,6 +52,7 @@ export const release = async (
       parserOpts: parseOptions,
       plugins: generatePlugins({
         commitAssets: processInputCommitAssets(),
+        disableGenerateChangeLog: processInputDisableGenerateChangelog(),
         isNodeModule: processInputNodeModule(),
         releaseAssets: processInputReleaseAssets(),
       }),

--- a/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
+++ b/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
@@ -186,12 +186,6 @@ Array [
   "@semantic-release/commit-analyzer",
   "@semantic-release/release-notes-generator",
   Array [
-    "@semantic-release/exec",
-    Object {
-      "prepareCmd": "npx prettier --write CHANGELOG.md",
-    },
-  ],
-  Array [
     "@semantic-release/git",
     Object {
       "assets": Array [],

--- a/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
+++ b/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
@@ -8,7 +8,7 @@ Array [
   Array [
     "@semantic-release/exec",
     Object {
-      "prepareCmd": "npx prettier --write CHANGELOG.md",
+      "prepareCmd": "npx prettier --parser markdown --write CHANGELOG.md",
     },
   ],
   Array [
@@ -41,7 +41,7 @@ Array [
   Array [
     "@semantic-release/exec",
     Object {
-      "prepareCmd": "npx prettier --write CHANGELOG.md",
+      "prepareCmd": "npx prettier --parser markdown --write CHANGELOG.md",
     },
   ],
   Array [
@@ -82,7 +82,7 @@ Array [
   Array [
     "@semantic-release/exec",
     Object {
-      "prepareCmd": "npx prettier --write CHANGELOG.md",
+      "prepareCmd": "npx prettier --parser markdown --write CHANGELOG.md",
     },
   ],
   Array [
@@ -114,7 +114,7 @@ Array [
   Array [
     "@semantic-release/exec",
     Object {
-      "prepareCmd": "npx prettier --write CHANGELOG.md",
+      "prepareCmd": "npx prettier --parser markdown --write CHANGELOG.md",
     },
   ],
   Array [
@@ -148,7 +148,7 @@ Array [
   Array [
     "@semantic-release/exec",
     Object {
-      "prepareCmd": "npx prettier --write CHANGELOG.md",
+      "prepareCmd": "npx prettier --parser markdown --write CHANGELOG.md",
     },
   ],
   Array [

--- a/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
+++ b/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
@@ -181,6 +181,35 @@ Array [
 ]
 `;
 
+exports[`generatePlugins excludes the changelog plugin when called with the disableGenerateChangelog parameter set to true 1`] = `
+Array [
+  "@semantic-release/commit-analyzer",
+  "@semantic-release/release-notes-generator",
+  Array [
+    "@semantic-release/exec",
+    Object {
+      "prepareCmd": "npx prettier --write CHANGELOG.md",
+    },
+  ],
+  Array [
+    "@semantic-release/git",
+    Object {
+      "assets": Array [],
+      "message": "chore(release): v\${nextRelease.version}",
+    },
+  ],
+  Array [
+    "@semantic-release/github",
+    Object {
+      "assets": Array [],
+      "failComment": false,
+      "releasedLabels": false,
+      "successComment": false,
+    },
+  ],
+]
+`;
+
 exports[`generatePlugins excludes the npm plugin when called with the isNodeModule parameter set to false 1`] = `
 Array [
   "@semantic-release/commit-analyzer",

--- a/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
+++ b/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
@@ -212,7 +212,7 @@ Array [
   Array [
     "@semantic-release/exec",
     Object {
-      "prepareCmd": "npx prettier --write CHANGELOG.md",
+      "prepareCmd": "npx prettier --parser markdown --write CHANGELOG.md",
     },
   ],
   Array [

--- a/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
+++ b/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
@@ -181,6 +181,29 @@ Array [
 ]
 `;
 
+exports[`generatePlugins excludes the changelog plugin when called with the disableChangelog parameter set to true 1`] = `
+Array [
+  "@semantic-release/commit-analyzer",
+  "@semantic-release/release-notes-generator",
+  Array [
+    "@semantic-release/git",
+    Object {
+      "assets": Array [],
+      "message": "chore(release): v\${nextRelease.version}",
+    },
+  ],
+  Array [
+    "@semantic-release/github",
+    Object {
+      "assets": Array [],
+      "failComment": false,
+      "releasedLabels": false,
+      "successComment": false,
+    },
+  ],
+]
+`;
+
 exports[`generatePlugins excludes the changelog plugin when called with the disableGenerateChangelog parameter set to true 1`] = `
 Array [
   "@semantic-release/commit-analyzer",

--- a/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
+++ b/src/utilities/__snapshots__/generatePlugins.spec.ts.snap
@@ -204,29 +204,6 @@ Array [
 ]
 `;
 
-exports[`generatePlugins excludes the changelog plugin when called with the disableGenerateChangelog parameter set to true 1`] = `
-Array [
-  "@semantic-release/commit-analyzer",
-  "@semantic-release/release-notes-generator",
-  Array [
-    "@semantic-release/git",
-    Object {
-      "assets": Array [],
-      "message": "chore(release): v\${nextRelease.version}",
-    },
-  ],
-  Array [
-    "@semantic-release/github",
-    Object {
-      "assets": Array [],
-      "failComment": false,
-      "releasedLabels": false,
-      "successComment": false,
-    },
-  ],
-]
-`;
-
 exports[`generatePlugins excludes the npm plugin when called with the isNodeModule parameter set to false 1`] = `
 Array [
   "@semantic-release/commit-analyzer",

--- a/src/utilities/generatePlugins.spec.ts
+++ b/src/utilities/generatePlugins.spec.ts
@@ -1,12 +1,26 @@
 import { generatePlugins } from './generatePlugins';
 
 describe('generatePlugins', (): void => {
+  it('excludes the changelog plugin when called with the disableGenerateChangelog parameter set to true', (): void => {
+    expect.assertions(1);
+
+    expect(
+      generatePlugins({
+        commitAssets: [],
+        disableGenerateChangeLog: true,
+        isNodeModule: false,
+        releaseAssets: [],
+      }),
+    ).toMatchSnapshot();
+  });
+
   it('excludes the npm plugin when called with the isNodeModule parameter set to false', (): void => {
     expect.assertions(1);
 
     expect(
       generatePlugins({
         commitAssets: [],
+        disableGenerateChangeLog: false,
         isNodeModule: false,
         releaseAssets: [],
       }),
@@ -19,6 +33,7 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: [],
+        disableGenerateChangeLog: false,
         isNodeModule: false,
         releaseAssets: [],
       }),
@@ -31,6 +46,7 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: [],
+        disableGenerateChangeLog: false,
         isNodeModule: true,
         releaseAssets: [],
       }),
@@ -43,6 +59,7 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: [],
+        disableGenerateChangeLog: false,
         isNodeModule: true,
         releaseAssets: [],
       }),
@@ -55,6 +72,7 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: ['./src'],
+        disableGenerateChangeLog: false,
         isNodeModule: false,
         releaseAssets: [],
       }),
@@ -67,6 +85,7 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: [],
+        disableGenerateChangeLog: false,
         isNodeModule: false,
         releaseAssets: ['./src'],
       }),

--- a/src/utilities/generatePlugins.spec.ts
+++ b/src/utilities/generatePlugins.spec.ts
@@ -1,13 +1,13 @@
 import { generatePlugins } from './generatePlugins';
 
 describe('generatePlugins', (): void => {
-  it('excludes the changelog plugin when called with the disableGenerateChangelog parameter set to true', (): void => {
+  it('excludes the changelog plugin when called with the disableChangelog parameter set to true', (): void => {
     expect.assertions(1);
 
     expect(
       generatePlugins({
         commitAssets: [],
-        disableGenerateChangeLog: true,
+        disableChangeLog: true,
         isNodeModule: false,
         releaseAssets: [],
       }),

--- a/src/utilities/generatePlugins.spec.ts
+++ b/src/utilities/generatePlugins.spec.ts
@@ -20,7 +20,6 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: [],
-        disableGenerateChangeLog: false,
         isNodeModule: false,
         releaseAssets: [],
       }),
@@ -33,7 +32,6 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: [],
-        disableGenerateChangeLog: false,
         isNodeModule: false,
         releaseAssets: [],
       }),
@@ -46,7 +44,6 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: [],
-        disableGenerateChangeLog: false,
         isNodeModule: true,
         releaseAssets: [],
       }),
@@ -59,7 +56,6 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: [],
-        disableGenerateChangeLog: false,
         isNodeModule: true,
         releaseAssets: [],
       }),
@@ -72,7 +68,6 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: ['./src'],
-        disableGenerateChangeLog: false,
         isNodeModule: false,
         releaseAssets: [],
       }),
@@ -85,7 +80,6 @@ describe('generatePlugins', (): void => {
     expect(
       generatePlugins({
         commitAssets: [],
-        disableGenerateChangeLog: false,
         isNodeModule: false,
         releaseAssets: ['./src'],
       }),

--- a/src/utilities/generatePlugins.ts
+++ b/src/utilities/generatePlugins.ts
@@ -20,7 +20,7 @@ export const generatePlugins = ({
           [
             '@semantic-release/exec',
             {
-              prepareCmd: 'npx prettier --write CHANGELOG.md',
+              prepareCmd: 'npx prettier --parser markdown --write CHANGELOG.md',
             },
           ] as PluginSpec,
         ]

--- a/src/utilities/generatePlugins.ts
+++ b/src/utilities/generatePlugins.ts
@@ -15,14 +15,16 @@ export const generatePlugins = ({
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     ...(disableGenerateChangeLog === false
-      ? ['@semantic-release/changelog']
+      ? [
+          '@semantic-release/changelog',
+          [
+            '@semantic-release/exec',
+            {
+              prepareCmd: 'npx prettier --write CHANGELOG.md',
+            },
+          ] as PluginSpec,
+        ]
       : []),
-    [
-      '@semantic-release/exec',
-      {
-        prepareCmd: 'npx prettier --write CHANGELOG.md',
-      },
-    ],
     ...(isNodeModule === true
       ? [
           [

--- a/src/utilities/generatePlugins.ts
+++ b/src/utilities/generatePlugins.ts
@@ -2,7 +2,7 @@ import { PluginSpec } from 'semantic-release';
 
 export const generatePlugins = ({
   commitAssets,
-  disableGenerateChangeLog = false,
+  disableGenerateChangeLog,
   isNodeModule,
   releaseAssets,
 }: {

--- a/src/utilities/generatePlugins.ts
+++ b/src/utilities/generatePlugins.ts
@@ -2,17 +2,21 @@ import { PluginSpec } from 'semantic-release';
 
 export const generatePlugins = ({
   commitAssets,
+  disableGenerateChangeLog = false,
   isNodeModule,
   releaseAssets,
 }: {
   commitAssets: string[];
+  disableGenerateChangeLog: boolean;
   isNodeModule: boolean;
   releaseAssets: string[];
 }): PluginSpec[] => {
   return [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    '@semantic-release/changelog',
+    ...(disableGenerateChangeLog === false
+      ? ['@semantic-release/changelog']
+      : []),
     [
       '@semantic-release/exec',
       {
@@ -33,7 +37,7 @@ export const generatePlugins = ({
       '@semantic-release/git',
       {
         assets: [
-          './CHANGELOG.md',
+          ...(disableGenerateChangeLog === false ? ['./CHANGELOG.md'] : []),
           ...commitAssets,
           ...(isNodeModule
             ? ['./package.json', './package-lock.json', './yarn-lock.yaml']

--- a/src/utilities/generatePlugins.ts
+++ b/src/utilities/generatePlugins.ts
@@ -2,12 +2,12 @@ import { PluginSpec } from 'semantic-release';
 
 export const generatePlugins = ({
   commitAssets,
-  disableGenerateChangeLog,
+  disableGenerateChangeLog = false,
   isNodeModule,
   releaseAssets,
 }: {
   commitAssets: string[];
-  disableGenerateChangeLog: boolean;
+  disableGenerateChangeLog?: boolean;
   isNodeModule: boolean;
   releaseAssets: string[];
 }): PluginSpec[] => {

--- a/src/utilities/generatePlugins.ts
+++ b/src/utilities/generatePlugins.ts
@@ -2,19 +2,19 @@ import { PluginSpec } from 'semantic-release';
 
 export const generatePlugins = ({
   commitAssets,
-  disableGenerateChangeLog = false,
+  disableChangeLog = false,
   isNodeModule,
   releaseAssets,
 }: {
   commitAssets: string[];
-  disableGenerateChangeLog?: boolean;
+  disableChangeLog?: boolean;
   isNodeModule: boolean;
   releaseAssets: string[];
 }): PluginSpec[] => {
   return [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    ...(disableGenerateChangeLog === false
+    ...(disableChangeLog === false
       ? [
           '@semantic-release/changelog',
           [
@@ -39,7 +39,7 @@ export const generatePlugins = ({
       '@semantic-release/git',
       {
         assets: [
-          ...(disableGenerateChangeLog === false ? ['./CHANGELOG.md'] : []),
+          ...(disableChangeLog === false ? ['./CHANGELOG.md'] : []),
           ...commitAssets,
           ...(isNodeModule
             ? ['./package.json', './package-lock.json', './yarn-lock.yaml']

--- a/src/utilities/inputProcessors.spec.ts
+++ b/src/utilities/inputProcessors.spec.ts
@@ -2,6 +2,7 @@ import * as actionsCore from '@actions/core';
 
 import {
   processInputCommitAssets,
+  processInputDisableGenerateChangelog,
   processInputDryRun,
   processInputNodeModule,
   processInputReleaseAssets,
@@ -18,6 +19,18 @@ describe('processInputNodeModule', (): void => {
     getInputSpy.mockReturnValue('true');
 
     const result = processInputNodeModule();
+
+    expect(result).toStrictEqual(true);
+  });
+});
+
+describe('processInputDisableGenerateChangelog', (): void => {
+  it("returns true when the value of the disable-generate-changelog input is set to 'true'", (): void => {
+    expect.assertions(1);
+
+    getInputSpy.mockReturnValue('true');
+
+    const result = processInputDisableGenerateChangelog();
 
     expect(result).toStrictEqual(true);
   });

--- a/src/utilities/inputProcessors.spec.ts
+++ b/src/utilities/inputProcessors.spec.ts
@@ -2,7 +2,7 @@ import * as actionsCore from '@actions/core';
 
 import {
   processInputCommitAssets,
-  processInputDisableGenerateChangelog,
+  processInputDisableChangelog,
   processInputDryRun,
   processInputNodeModule,
   processInputReleaseAssets,
@@ -30,7 +30,7 @@ describe('processInputDisableGenerateChangelog', (): void => {
 
     getInputSpy.mockReturnValue('true');
 
-    const result = processInputDisableGenerateChangelog();
+    const result = processInputDisableChangelog();
 
     expect(result).toStrictEqual(true);
   });

--- a/src/utilities/inputProcessors.ts
+++ b/src/utilities/inputProcessors.ts
@@ -4,7 +4,7 @@ import { BranchSpec } from 'semantic-release';
 
 export enum InputParameters {
   CommitAssets = 'commit-assets',
-  DisableGenerateChangelog = 'disable-generate-changelog',
+  DisableChangelog = 'disable-generate-changelog',
   DryRun = 'dry-run',
   NodeModule = 'node-module',
   ReleaseAssets = 'release-assets',
@@ -131,8 +131,8 @@ const validateInputReleaseRules = (input: ReleaseRule[]): ReleaseRule[] => {
 export const processInputNodeModule = (): boolean =>
   getInput(InputParameters.NodeModule) === 'true';
 
-export const processInputDisableGenerateChangelog = (): boolean =>
-  getInput(InputParameters.DisableGenerateChangelog) === 'true';
+export const processInputDisableChangelog = (): boolean =>
+  getInput(InputParameters.DisableChangelog) === 'true';
 
 export const processInputDryRun = (): boolean =>
   getInput(InputParameters.DryRun) === 'true';

--- a/src/utilities/inputProcessors.ts
+++ b/src/utilities/inputProcessors.ts
@@ -4,6 +4,7 @@ import { BranchSpec } from 'semantic-release';
 
 export enum InputParameters {
   CommitAssets = 'commit-assets',
+  DisableGenerateChangelog = 'disable-generate-changelog',
   DryRun = 'dry-run',
   NodeModule = 'node-module',
   ReleaseAssets = 'release-assets',
@@ -129,6 +130,9 @@ const validateInputReleaseRules = (input: ReleaseRule[]): ReleaseRule[] => {
 
 export const processInputNodeModule = (): boolean =>
   getInput(InputParameters.NodeModule) === 'true';
+
+export const processInputDisableGenerateChangelog = (): boolean =>
+  getInput(InputParameters.DisableGenerateChangelog) === 'true';
 
 export const processInputDryRun = (): boolean =>
   getInput(InputParameters.DryRun) === 'true';


### PR DESCRIPTION
This pull request adds an input parameter that allows for disabling generating a CHANGELOG.md file. In order to not break the current implementations, generating the CHANGELOG.md file remains enabled by default.

Resolves issues:
- https://github.com/ridedott/release-me-action/issues/410
- https://github.com/ridedott/release-me-action/issues/228 (explicitly related to the `@semantic-release/changelog` plugin)