### PR TITLE
revert: fix: file-url

### DIFF
--- a/src/utilities/git.ts
+++ b/src/utilities/git.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import * as execa from 'execa';
-import fileUrl from 'file-url';
+import * as fileUrl from 'file-url';
 import { directory } from 'tempy';
 
 /**


### PR DESCRIPTION
This reverts commit fa66833a4d42c7dd4cf148c2679bc055467d84d6.

A commit was accidentally pushed to master because of incorrect branch protection rules. It caused a [broken release](https://github.com/ridedott/release-me-action/commit/b59081145fcca2289edb80544f73308830ac0d53) which is why this revert is necessary.