### PR TITLE
fix: wrong input parameter for disable-changelog

### DIFF
--- a/src/utilities/inputProcessors.ts
+++ b/src/utilities/inputProcessors.ts
@@ -12,7 +12,7 @@ export enum InputParameters {
   AdditionalPlugins = 'additional-plugins',
   CommitAssets = 'commit-assets',
   ConfigFile = 'config-file',
-  DisableChangelog = 'disable-generate-changelog',
+  DisableChangelog = 'disable-changelog',
   DryRun = 'dry-run',
   NodeModule = 'node-module',
   ReleaseAssets = 'release-assets',


### PR DESCRIPTION
The whole docs mentions to use `disable-changelog` to disable generating/updating the CHANGELOG.md file but when using it, nothing changes and the changelog is still updated. To properly use `disable-changelog`, you currently need to use `disable-generate-changelog`.

This PR fixes this issue.