### PR TITLE
docs: Update example - typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ steps:
       # If not specified, Semantic Release will use its default branches
       # configuration, specified in the API documentation:
       # https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches
-      release-branches: '["+([0-9])?(.{+([0-9]),x}).x","master","next","next-major",{"name":"beta","prerelease":"beta"},{"name":"alpha","prerelease":"alpha"}]',
+      release-branches: '["+([0-9])?(.{+([0-9]),x}).x","master","next","next-major",{"name":"beta","prerelease":"beta"},{"name":"alpha","prerelease":"alpha"}]'
       # Commit the new line separated glob patterns to the repository as part
       # of the release process.
       commit-assets: |


### PR DESCRIPTION
### Changes:
- Remove `,`