### PR TITLE
chore: remove reviewers from dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,8 +14,6 @@ updates:
           - '>=2'
     open-pull-requests-limit: 99
     package-ecosystem: github-actions
-    reviewers:
-      - 'ridedott/platform'
     schedule:
       interval: daily
   - allow:
@@ -26,8 +24,6 @@ updates:
     directory: /
     open-pull-requests-limit: 99
     package-ecosystem: npm
-    reviewers:
-      - 'ridedott/platform'
     schedule:
       interval: daily
     versioning-strategy: increase


### PR DESCRIPTION
Instead rely on CODEOWNERS.